### PR TITLE
Rename Pro1 assets to Codex1

### DIFF
--- a/codex1.md
+++ b/codex1.md
@@ -1,0 +1,77 @@
+# PulseChain HEX Strategy Iteration — codex1
+
+## Objective
+
+Improve the repository's cost-aware HEX/DAI trading strategies using the
+documented swap-cost buckets while leaving a reproducible paper trail of the
+changes introduced by the `codex1` agent. All work references the 5 minute
+`pdai_ohlcv_dai_730day_5m.csv` dataset and the fee model stored in
+`swap_cost_cache.json` as described in `newstrats/local.md`.
+
+## Key Changes
+
+### 1. Regime-aware Donchian breakout (new)
+
+* Added `strategies/donchian_champion_regime_codex1_strategy.py`, a
+  Donchian-breakout derivative that layers three risk filters on top of the
+  existing Champion family:
+  * fast/slow EMA regime check with slope gating,
+  * macro EMA guardrail (14‑day) to avoid structurally bearish phases,
+  * ATR-ratio based trailing stop with post-loss cooling-off period (10 days).
+  The implementation inherits the bucketed swap-cost semantics enforced by the
+  evaluation harness, so results remain compatible with
+  `swap_cost_cache.json`.【F:strategies/donchian_champion_regime_codex1_strategy.py†L1-L162】
+
+### 2. Evaluation & reporting updates
+
+* Registered the new strategy with the quick evaluation runner so the
+  aggregated console table now highlights the `RegimeCodex1` variant alongside
+  existing Champion strategies.【F:scripts/evaluate_vost_strategies.py†L21-L31】【F:scripts/evaluate_vost_strategies.py†L116-L120】
+* Extended the CSV export utility with CLI arguments (`--data`, `--swap-cost`
+  and `--output`) and appended the new strategy to the structured summary so it
+  surfaces automatically in downstream analytics.【F:scripts/export_strategy_performance_csv.py†L1-L58】【F:scripts/export_strategy_performance_csv.py†L68-L108】
+
+## Performance Snapshot (swap-cost adjusted)
+
+All metrics generated with:
+
+```bash
+python scripts/evaluate_vost_strategies.py --swap-cost-cache swap_cost_cache.json --trade-size 5000
+python scripts/export_strategy_performance_csv.py --swap-cost-cache swap_cost_cache.json
+```
+
+| Strategy | Trade Size (DAI) | Total Return | Max DD | Trades | Notes |
+|----------|-----------------:|-------------:|-------:|-------:|-------|
+| CSMARevert | 5 000 | +5 418 % | −92.2 % | 21 | Still the blow-off crash catcher; huge upside, extreme risk.【db0475†L6-L9】 |
+| DonchianChampionDynamic | 5 000 | +4 600 % | −49.0 % | 34 | Prior best breakout baseline (Champion v4).【db0475†L6-L9】 |
+| **DonchianChampionRegimeCodex1** | 5 000 | **+403 %** | **−40.9 %** | 22 | New regime-gated variant; trades far less during bearish regimes.【db0475†L6-L10】【F:strategy_performance_summary.csv†L20-L22】 |
+| DonchianChampionRegimeCodex1 | 10 000 | +241 % | −49.5 % | 22 | Maintains positive net even with heavier fee bucket.【F:strategy_performance_summary.csv†L21-L22】 |
+| DonchianChampionRegimeCodex1 | 25 000 | +21 % | −66.9 % | 22 | Largest trade bucket remains profitable after costs; losses capped by tighter trail.【F:strategy_performance_summary.csv†L22-L22】 |
+| DonchianChampionRegimeCodex1 (last 3 mo) | 5 000 | −24.7 % | −28.4 % | 2 | Only two trades triggered; post-loss cooldown prevented further churn in the persistent downtrend.【F:strategy_performance_summary.csv†L53-L55】 |
+| DonchianChampionRegimeCodex1 (last 1 mo) | 5 000 | 0 % | 0 % | 0 | Macro filter kept the strategy flat during the most recent selloff.【F:strategy_performance_summary.csv†L86-L88】 |
+
+> **Observation.** The new cooldown logic materially reduces the number of
+> post-loss re-entries. Compared with the raw Champion variants it sacrifices
+> headline total return but slashes drawdown and recent-period fee bleed.
+
+## How to Reproduce
+
+1. Install dependencies (`pip install -r requirements.txt`).
+2. Ensure `data/pdai_ohlcv_dai_730day_5m.csv` and `swap_cost_cache.json`
+   are present (default locations).
+3. Run the evaluation commands shown above to refresh the console summary and
+   CSV report. The CSV now contains 99 rows, including full/3 mo/1 mo slices for
+   the new strategy across 5k/10k/25k buckets.【F:strategy_performance_summary.csv†L1-L99】
+
+## Next Iteration Ideas
+
+* Investigate a hybridised approach that mixes CSMA rebounds with RegimeCodex1
+  trend legs to achieve positive returns across all rolling windows while
+  keeping max drawdown below 50 %.
+* Explore adaptive position sizing based on `atr_ratio` so the strategy scales
+  down automatically in turbulent regimes, mitigating the remaining 25 k DAI
+  drawdown sensitivity.
+* Consider layering a macro economic filter (e.g. HEX on-chain inflow or PLS
+  strength) to further reduce the −25 % three-month slide without starving the
+  strategy of entries during broad market recoveries.
+

--- a/scripts/evaluate_vost_strategies.py
+++ b/scripts/evaluate_vost_strategies.py
@@ -31,6 +31,9 @@ from strategies.donchian_champion_strategy import (
     DonchianChampionAggressiveStrategy,
     DonchianChampionDynamicStrategy,
 )
+from strategies.donchian_champion_regime_codex1_strategy import (
+    DonchianChampionRegimeCodex1Strategy,
+)
 from strategies.tight_trend_follow_strategy import TightTrendFollowStrategy
 from strategies.hybrid_v2_strategy import HybridV2Strategy
 
@@ -243,6 +246,7 @@ def main() -> None:
         ('DonchianChampion', DonchianChampionStrategy()),
         ('DonchianChampionAggressive', DonchianChampionAggressiveStrategy()),
         ('DonchianChampionDynamic', DonchianChampionDynamicStrategy()),
+        ('DonchianChampionRegimeCodex1', DonchianChampionRegimeCodex1Strategy()),
         ('HybridV2', HybridV2Strategy()),
         ('TightTrendFollow', TightTrendFollowStrategy()),
         ('MultiWeekBreakout', MultiWeekBreakoutStrategy()),

--- a/strategies/donchian_champion_regime_codex1_strategy.py
+++ b/strategies/donchian_champion_regime_codex1_strategy.py
@@ -1,0 +1,238 @@
+"""Regime-gated Donchian breakout with dynamic trailing stop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+from .base_strategy import BaseStrategy
+
+
+def _ema(series: pd.Series, span: int) -> pd.Series:
+    return series.ewm(span=max(1, span), adjust=False).mean()
+
+
+def _atr_ratio(df: pd.DataFrame, period: int) -> pd.Series:
+    high = df['high'] if 'high' in df.columns else df['price']
+    low = df['low'] if 'low' in df.columns else df['price']
+    close = df['price'] if 'price' in df.columns else df['close']
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [
+            (high - low).abs(),
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    atr = tr.rolling(period, min_periods=period).mean()
+    return (atr / close).fillna(0.0)
+
+
+@dataclass
+class _TradeState:
+    in_position: bool = False
+    peak_price: float = 0.0
+    entry_price: float = 0.0
+    cooldown: int = 0
+
+
+class DonchianChampionRegimeCodex1Strategy(BaseStrategy):
+    """Donchian breakout with EMA regime gating and volatility-aware trailing."""
+
+    def __init__(self, parameters: Dict | None = None):
+        defaults = {
+            'entry_days': 11.0,
+            'exit_days': 2.0,
+            'ema_exit_days': 3.0,
+            'regime_fast_days': 1.0,
+            'regime_slow_days': 5.0,
+            'min_regime_slope': 0.0008,
+            'exit_regime_slope': -0.0010,
+            'macro_days': 14.0,
+            'macro_min_slope': 0.0008,
+            'macro_exit_slope': -0.0006,
+            'macro_buffer_pct': 0.020,
+            'atr_days': 1.0,
+            'trail_base': 0.18,
+            'trail_k': 0.45,
+            'trail_min': 0.12,
+            'trail_max': 0.32,
+            'max_atr_ratio': 0.18,
+            'cooldown_hours': 24.0,
+            'post_loss_cooldown_hours': 240.0,
+            'timeframe_minutes': 5,
+        }
+        if parameters:
+            defaults.update(parameters)
+        super().__init__('DonchianChampionRegimeCodex1Strategy', defaults)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _window_bars(self, days: float) -> int:
+        timeframe = float(self.parameters.get('timeframe_minutes', 5))
+        bars = int(round(days * 24 * 60 / timeframe))
+        return max(1, bars)
+
+    def _hours_to_bars(self, hours: float) -> int:
+        timeframe = float(self.parameters.get('timeframe_minutes', 5))
+        bars = int(round(hours * 60 / timeframe))
+        return max(1, bars)
+
+    # ------------------------------------------------------------------
+    # Indicator pipeline
+    # ------------------------------------------------------------------
+    def calculate_indicators(self, data: pd.DataFrame) -> pd.DataFrame:
+        if not self.validate_data(data):
+            return data
+
+        df = data.copy()
+        price = df['price'] if 'price' in df.columns else df['close']
+        df['price'] = price
+
+        entry_bars = self._window_bars(float(self.parameters['entry_days']))
+        exit_bars = self._window_bars(float(self.parameters['exit_days']))
+        ema_exit_bars = self._window_bars(float(self.parameters['ema_exit_days']))
+        fast_bars = self._window_bars(float(self.parameters['regime_fast_days']))
+        slow_bars = self._window_bars(float(self.parameters['regime_slow_days']))
+        macro_bars = self._window_bars(float(self.parameters['macro_days']))
+        atr_bars = self._window_bars(float(self.parameters['atr_days']))
+
+        slope_bars = max(1, fast_bars)
+        macro_slope_bars = max(1, self._window_bars(float(self.parameters['macro_days']) / 2))
+
+        df['donchian_high'] = price.rolling(entry_bars, min_periods=entry_bars).max().shift(1)
+        df['donchian_low'] = price.rolling(exit_bars, min_periods=exit_bars).min().shift(1)
+        df['ema_exit'] = _ema(price, ema_exit_bars)
+        df['ema_fast'] = _ema(price, fast_bars)
+        df['ema_slow'] = _ema(price, slow_bars)
+        df['ema_fast_slope'] = df['ema_fast'].diff(slope_bars) / df['ema_fast'].shift(slope_bars)
+        df['ema_macro'] = _ema(price, macro_bars)
+        df['ema_macro_slope'] = df['ema_macro'].diff(macro_slope_bars) / df['ema_macro'].shift(macro_slope_bars)
+        df['atr_ratio'] = _atr_ratio(df, atr_bars)
+        df['atr_smooth'] = df['atr_ratio'].rolling(slope_bars, min_periods=slope_bars).mean()
+
+        return df
+
+    # ------------------------------------------------------------------
+    # Signal logic
+    # ------------------------------------------------------------------
+    def generate_signals(self, data: pd.DataFrame) -> pd.DataFrame:
+        df = data.copy()
+        if 'donchian_high' not in df.columns:
+            df = self.calculate_indicators(df)
+
+        df['buy_signal'] = False
+        df['sell_signal'] = False
+        df['signal_strength'] = 0.0
+
+        price = df['price'].to_numpy(float)
+        highs = df['donchian_high'].to_numpy(float)
+        lows = df['donchian_low'].to_numpy(float)
+        ema_exit = df['ema_exit'].to_numpy(float)
+        ema_fast = df['ema_fast'].to_numpy(float)
+        ema_slow = df['ema_slow'].to_numpy(float)
+        fast_slope = df['ema_fast_slope'].to_numpy(float)
+        ema_macro = df['ema_macro'].to_numpy(float)
+        macro_slope = df['ema_macro_slope'].to_numpy(float)
+        atr_ratio = df['atr_ratio'].to_numpy(float)
+        atr_smooth = df['atr_smooth'].to_numpy(float)
+
+        min_regime_slope = float(self.parameters['min_regime_slope'])
+        exit_regime_slope = float(self.parameters['exit_regime_slope'])
+        macro_min_slope = float(self.parameters['macro_min_slope'])
+        macro_exit_slope = float(self.parameters['macro_exit_slope'])
+        macro_buffer = float(self.parameters['macro_buffer_pct'])
+        max_atr_ratio = float(self.parameters['max_atr_ratio'])
+
+        trail_base = float(self.parameters['trail_base'])
+        trail_k = float(self.parameters['trail_k'])
+        trail_min = float(self.parameters['trail_min'])
+        trail_max = float(self.parameters['trail_max'])
+
+        cooldown_bars = self._hours_to_bars(float(self.parameters['cooldown_hours']))
+        loss_cooldown_bars = self._hours_to_bars(float(self.parameters['post_loss_cooldown_hours']))
+
+        state = _TradeState(False, 0.0, 0.0, 0)
+
+        for i in range(len(df)):
+            px = price[i]
+            hi = highs[i]
+            lo = lows[i]
+            ema_e = ema_exit[i]
+            fast = ema_fast[i]
+            slow = ema_slow[i]
+            fast_sl = fast_slope[i]
+            macro = ema_macro[i]
+            macro_sl = macro_slope[i]
+            vol = atr_ratio[i]
+            vol_avg = atr_smooth[i]
+
+            if np.isnan(px) or np.isnan(fast) or np.isnan(slow):
+                if state.cooldown > 0:
+                    state.cooldown -= 1
+                continue
+
+            regime_ok = fast > slow and (np.isnan(fast_sl) or fast_sl >= min_regime_slope)
+            macro_ok = (
+                not np.isnan(macro)
+                and px >= macro * (1.0 + macro_buffer)
+                and (np.isnan(macro_sl) or macro_sl >= macro_min_slope)
+            )
+            vol_ok = np.isnan(vol_avg) or vol_avg <= max_atr_ratio
+
+            if not state.in_position:
+                if state.cooldown > 0:
+                    state.cooldown -= 1
+                    continue
+
+                if (
+                    not np.isnan(hi)
+                    and px >= hi
+                    and regime_ok
+                    and macro_ok
+                    and vol_ok
+                ):
+                    df.iat[i, df.columns.get_loc('buy_signal')] = True
+                    df.iat[i, df.columns.get_loc('signal_strength')] = 1.0
+                    state.in_position = True
+                    state.peak_price = px
+                    state.entry_price = px
+            else:
+                state.peak_price = max(state.peak_price, px)
+                dyn_dd = trail_base + trail_k * (vol if not np.isnan(vol) else 0.0)
+                dyn_dd = min(max(dyn_dd, trail_min), trail_max)
+
+                trail_stop = state.peak_price > 0 and px <= state.peak_price * (1.0 - dyn_dd)
+                exit_donchian = (
+                    not np.isnan(lo)
+                    and px <= lo
+                    and not np.isnan(ema_e)
+                    and px < ema_e
+                )
+                regime_break = fast <= slow or (not np.isnan(fast_sl) and fast_sl <= exit_regime_slope)
+                macro_break = (
+                    np.isnan(macro)
+                    or px <= macro * (1.0 - macro_buffer)
+                    or (not np.isnan(macro_sl) and macro_sl <= macro_exit_slope)
+                )
+                vol_spike = not np.isnan(vol) and vol > max_atr_ratio * 1.3
+
+                if trail_stop or exit_donchian or regime_break or macro_break or vol_spike:
+                    df.iat[i, df.columns.get_loc('sell_signal')] = True
+                    df.iat[i, df.columns.get_loc('signal_strength')] = 1.0
+                    loss_exit = state.entry_price > 0 and px < state.entry_price
+                    state.in_position = False
+                    state.peak_price = 0.0
+                    state.entry_price = 0.0
+                    state.cooldown = loss_cooldown_bars if loss_exit else cooldown_bars
+
+            if not state.in_position and state.cooldown > 0 and not df.iat[i, df.columns.get_loc('sell_signal')]:
+                state.cooldown = max(state.cooldown - 1, 0)
+
+        return df
+


### PR DESCRIPTION
## Summary
- add a regime-gated Donchian breakout implementation with ATR-based trailing and post-loss cooldown controls, now published as DonchianChampionRegimeCodex1Strategy
- register the new strategy with the evaluation CLI and extend the CSV exporter with CLI arguments and documentation, updating references to the Codex1 naming
- document the workflow and results in codex1.md for reproducibility

## Testing
- python scripts/evaluate_vost_strategies.py --swap-cost-cache swap_cost_cache.json --trade-size 5000
- python scripts/export_strategy_performance_csv.py --swap-cost-cache swap_cost_cache.json

------
https://chatgpt.com/codex/tasks/task_e_68e64ad9d7b083259ca6d19f7fc417ef